### PR TITLE
typo fixes: duplicate word, missing comma, trailing spaces

### DIFF
--- a/S3-practical-guide.md
+++ b/S3-practical-guide.md
@@ -15,17 +15,17 @@ theme: Plain Jane, 1
 
 ---
 
-## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations 
+## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations
 
 ### Effective Collaboration At Any Scale
 
-Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**. 
+Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**.
 
 S3 brings you an extensive collection of guidelines and practices (so-called “patterns”) that have proven helpful for organizations to **improve performance, alignment, fulfillment and wellbeing**.
 
 These patterns help you discover how to best reach your objectives and navigate complexity, one step at a time, **without the need for sudden radical reorganization or planning a long-term change initiative**:
 
- Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go. 
+ Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go.
 
 **Regardless of your position in the organization**, you will find patterns that are relevant and helpful for you.
 
@@ -63,7 +63,7 @@ Sociocracy 3.0 is:
 
 -   a bit of history and a brief overview of some basic concepts behind S3
 -   a description of all the patterns in S3
--   an appendix 
+-   an appendix
     -   changelog
     -   info about authors and acknowledgments
     -   the license
@@ -89,9 +89,9 @@ In 1926, the Dutch reformist educator and Quaker **Kees Boeke**, established a r
 
 During the late 1990s and early 2000s, several non-Dutch speaking people came across sociocracy, but it wasn't until 2007 when **Sharon Villines and John Buck** launched their book, "We the People", that sociocracy became widely accessible to the English speaking world, and from there has began to migrate into several other languages.
 
-Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral. 
+Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral.
 
-In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015. 
+In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile, and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015.
 
 **Liliana David** joined the team soon after and together they regularly collaborate to develop both the framework and the website.
 
@@ -118,7 +118,7 @@ We also love agile, lean, Kanban, the Core Protocols, NVC, and many other ideas 
 
 Therefore we decided to devote some of our time to develop and evolve Sociocracy, integrating it with many of these other potent ideas, to make it available and applicable to as many organizations as possible.
 
-To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability. 
+To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability.
 
 ### The Name
 
@@ -178,7 +178,7 @@ _James Priest, Bernhard Bockelbrink and Liliana David_
 
 ## Basic Concepts
 
-Before diving into the content, consider taking time to learn about some basic concepts behind S3: 
+Before diving into the content, consider taking time to learn about some basic concepts behind S3:
 
 -   What is a pattern?
 -   The Seven Principles
@@ -192,7 +192,7 @@ For any terms you don't understand check out the glossary at the end.
 
 ---
 
-### Patterns 
+### Patterns
 
 _A **pattern** is a template for successfully navigating a specific context._
 
@@ -205,7 +205,7 @@ _A **pattern** is a template for successfully navigating a specific context._
 
 ---
 
-### The Seven Principles 
+### The Seven Principles
 
 
 Sociocracy is built on seven principles that shape organizational culture. Since the seven principles are reflected in all of the patterns, understanding these principles is helpful for adopting and paramount to adapting Sociocracy 3.0 patterns.
@@ -239,7 +239,7 @@ Every member of the organization is accountable for effectively responding to or
 Individuals are also accountable for their work, ongoing learning and development, and for supporting one another.
 
 Everyone in an organization is accountable for aligning activity with organizational values.
- 
+
 
 ---
 
@@ -252,7 +252,7 @@ Everyone in an organization is accountable for aligning activity with organizati
 
 _A **driver** is a person’s or a group's motive for responding to a specific situation._
 
-Drivers: 
+Drivers:
 
 -   can be used to derive goals, objectives, aims, mission, vision, purpose
 -   can change over time
@@ -314,19 +314,19 @@ While a decision of short-term consequence can easily be amended on the spot, ma
 
 Such agreements need to be documented, both to remember them and to support effective _review_, and to be communicated to people affected (who are ideally also _involved in the creation and evolution_ of those agreements).
 
-Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations: 
+Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations:
 
 _**Governance** in an organization (or a domain within it) is the act of setting objectives, and making and evolving decisions that guide people towards achieving them._
 
 _**Operations** is doing the work and organizing day to day activities within the constraints defined through governance._
 
-For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value. 
+For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value.
 
 There are many ways to distribute work and governance. Sometimes the governing body is a single person, e.g. in the case of a team lead, and sometimes it’s a group of people, e.g. in a circle where all circle members share responsibility for governance within the constraints of the domain.
 
 **Governance decisions** set constraints on activity and guide future decisions.
 
-This includes: 
+This includes:
 
 -   defining domains
 -   delegating influence to people
@@ -362,7 +362,7 @@ Depending on the constraints set by the delegator, teams have more or less licen
 Responses to [organizational drivers](glossary:organizational-driver) include:
 
 - direct action ([operations](glossary:operations))
-- organizing how work will be done 
+- organizing how work will be done
 - making governance decisions
 
 The response to an organizational driver is typically treated as an experiment that is evaluated and evolved over time.
@@ -410,11 +410,11 @@ A simple way to describe a driver is by explaining:
     -   the **need** of the organization in relation to this situation
     -   the **impact** of attending to that need
 
-Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision. 
+Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision.
 
 ![Describe Organizational Drivers](img/process/describe-organizational-drivers.png)
 
-### Example: 
+### Example:
 
 > _“The kitchen is a mess: there are no clean cups, the sink is full of dishes and it’s not possible to quickly grab a coffee and get right back to work. We need the kitchen in a usable state so we can stay focused on our work.”_
 
@@ -433,9 +433,9 @@ Describe the current situation:
 
 Explain the effect of this situation on the organization:
 
-- Clarify **why** the situation needs attention: how does it affect the organization? 
-- Be explicit about whether the effects are current or anticipated. 
-- Explain challenges, losses, opportunities or gains. 
+- Clarify **why** the situation needs attention: how does it affect the organization?
+- Be explicit about whether the effects are current or anticipated.
+- Explain challenges, losses, opportunities or gains.
 
 ### 3. Need
 
@@ -443,7 +443,7 @@ Explain the effect of this situation on the organization:
 
 Explain the [need](glossary:need) of the organization in relation to this situation:
 
-- A **need of an organization** is anything a team (or individual) requires to effectively account for a [domain](glossary:domain). 
+- A **need of an organization** is anything a team (or individual) requires to effectively account for a [domain](glossary:domain).
 - Be specific on whose need it is (“we need”, “they need”, “I need”).
 - If there’s disagreement about the need, it helps to zoom out from specific solutions and focus on what the organization is lacking in this situation.
 
@@ -461,7 +461,7 @@ Describe the impact of attending to that need:
 Aim for one or two sentences, so that the information is easy to remember and process.
 
 Besides the summary, more details about the driver may be kept in the logbook.
- 
+
 
 ### Review Drivers
 
@@ -554,7 +554,7 @@ Some helpful questions:
 
 _A **concern** is an assumption that doing something (even in the absence of objections) **might** stand in the way of (more) effective response to an organizational driver._
 
-In _Consent Decision Making_, concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).  
+In _Consent Decision Making_, concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).
 
 Bring up concerns if you consider them important and at least record them along with evaluation criteria.
 
@@ -655,7 +655,7 @@ There are many ways to co-create proposals. They typically follow a similar patt
 3. Generate ideas
 4. Design a proposal (often done by a smaller group)
 
-One way to co-create proposals is to use S3's _Proposal Forming_ pattern. 
+One way to co-create proposals is to use S3's _Proposal Forming_ pattern.
 
 ![A template for proposals](img/templates/proposal-template.png)
 
@@ -679,7 +679,7 @@ _Proposal Forming_ may also be used by an individual.
 
 ### Proposal Forming Steps
 
-**Consent to driver:** Briefly present the [driver](glossary:organizational-driver). _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_ 
+**Consent to driver:** Briefly present the [driver](glossary:organizational-driver). _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_
 
 **Deepen shared understanding of driver:** invite essential questions to understand the driver in more detail.
 
@@ -695,7 +695,7 @@ _Proposal Forming_ may also be used by an individual.
 
 ### Choosing Tuners
 
-Consider: 
+Consider:
 
 -   who should be there?
 -   who wants to be there?
@@ -735,7 +735,7 @@ A prerequisite to the selection process is a _clear description_ of the role's [
     -   proposing a nominee themselves or asking a group member
     -   inviting (some) nominees to agree who should be proposed
     -   inviting group dialogue to help reveal the strongest nominee
-7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an [objection](glossary:objection). 
+7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an [objection](glossary:objection).
 8. **Address and Resolve Objections,** beginning with any from the proposed nominee. _Objections may be resolved_ in many ways, including amending the role's domain description or by nominating someone else. When all objections are resolved, check with the (final) nominee again if they accept the role.
 9. **Celebrate:** Acknowledge reaching agreement and thank the person who will now keep the role.
 
@@ -783,7 +783,7 @@ Ask someone, "_would you be willing to help me with ..._?" The person asked acce
 
 ## Pattern 2.2: Peer Feedback
 
-Invite a peer to give you some constructive feedback on: 
+Invite a peer to give you some constructive feedback on:
 
 -   your performance in a role
 -   your general participation and contribution
@@ -871,7 +871,7 @@ Artful participation:
 
 ### Artful Participation: Self-Assessment
 
--   How can I support myself and others to participate more artfully? 
+-   How can I support myself and others to participate more artfully?
 -   Where are my interactions with others unhelpful or ineffective?
 -   Which agreements do I find hard to keep? What can I do to address this?
 -   What skills can I develop, that would support me to participate more artfully?
@@ -965,14 +965,14 @@ Be accountable:
 ---
 
 ## Pattern 3.6: Contract For Successful Collaboration
- 
+
 **Support successful collaboration from the start and build trust between parties by co-creating mutually beneficial and legally robust contracts.**
 
-A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies. 
+A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies.
 
 Developing shared understanding about needs and expectations is essential for successful collaboration.
 
-While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved. 
+While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved.
 
 This pattern refers to contracts relating related to collaboration around any business transaction between an organization and other parties (e.g. employees, consultants, service providers, shareholders or customers). It is especially relevant for contracts that have a significant influence on the future of an organization or one of its partners, such as:
 
@@ -1029,7 +1029,7 @@ Any contract can be changed at any time, provided all signatories agree. However
 
 Every contract influences the culture of the collaboration it governs, even when it appears to only describe *what* needs to be delivered:
 
-- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done 
+- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done
 - align the contract to the organizational culture (of all parties) and to legal requirements
 - build contracts that enable and encourage accountability
 
@@ -1049,7 +1049,7 @@ A transparent salary formula needs to suit an organization's context, and to be 
 
 Perception of fairness varies from person to person and according to context, so creating a salary formula requires developing a shared understanding of what is considered fair.
 
-When deciding (or agreeing) on a salary formula for an organization or department, consider: 
+When deciding (or agreeing) on a salary formula for an organization or department, consider:
 
 - what would be a suitable fixed subsistence guarantee
 - how to calculate compensation according to need, investment, productivity, or merit
@@ -1065,7 +1065,7 @@ Decide how to handle remuneration for changing roles and _develop a strategy_ fo
 ## Pattern 3.8: Support Role
 
 **Apply the role pattern to external contractors.**
-    
+
 -   clarify and describe the [driver](glossary:organizational-driver) for the _role_
 -   create a _domain description_
 -   if valuable, implement a selection process
@@ -1083,7 +1083,7 @@ External contractors consent to take on their role.
 Secure S3 principles and patterns in your bylaws as needed to protect **legal integrity** and **organizational culture**
 
 Consider:
-    
+
 -   consent and equivalence in decision making
 -   selection process for leadership roles
 -   organizational structure, [values](glossary:values) and [principles](glossary:principle)
@@ -1135,7 +1135,7 @@ A circle:
 -  **equivalence of circle members:**
     -   All members of a circle are equally accountable for [governance](glossary:governance) of the circle's domain.
 
-![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)  
+![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)
 
 
 ---
@@ -1157,7 +1157,7 @@ A role is a simple way for an organization (or [team](glossary:team)) to delegat
 
 A role keeper may maintain a governance [backlog](glossary:backlog), and a [logbook](glossary:logbook) to record and help them evolve their approach toward delivering [value](glossary:value).
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.
 
 ![People can take responsibility for more than one role](img/illustrations/roles.png)
 
@@ -1208,7 +1208,7 @@ Representatives (a.k.a. links):
 
 **Bring together a team of equivalent people with the mandate to execute on a specific set of requirements defined by a delegator.**
 
-A helping team: 
+A helping team:
 
 -   is a way for a [delegator](glossary:delegator) to expand their capacity
 -   may be self-organizing, or guided by a _coordinator_ chosen by the delegator
@@ -1232,14 +1232,14 @@ Members of the helping team:
 **Intentionally account for a domain by invitation rather than assignment and request that those invited contribute when they can.**
 
 The [delegator](glossary:delegator) of the open domain clarifies:
- 
+
 - the [primary driver](glossary:primary-driver), key responsibilities and constraints of the open domain
 - who is invited to contribute to the open domain
 - constraints relating to the delegator’s participation in the open domain’s [governance](glossary:governance)
 
 Depending on the constraints set by the delegator, contributors may only [organize and do work](glossary:operations), or take part in governance as well.
 
-A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain. 
+A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain.
 
 ![Open Domain](img/structural-patterns/open-domain.png)
 
@@ -1349,7 +1349,7 @@ Include the people involved and affected in regular evaluation of outcomes.
 -   initiate a process of continuous improvement, e.g. through Kanban or regular _retrospectives_
 -   members of the team pull in S3 patterns as required
 -   if valuable, iteratively expand the scope of the experiment to other teams
--   intentionally look out for impediments  
+-   intentionally look out for impediments
 
 ### Waste And Continuous Improvement
 
@@ -1390,10 +1390,10 @@ Agreements are created in response to [organizational drivers](glossary:organiza
 **Overall accountability** for an agreement lies with the people that make them.
 
 An agreement can include **delegation of specific responsibilities** to individuals or groups.
-   
+
 Record any **expectations** related to [deliverables](glossary:deliverable), behavior or resources in the context of the agreement.
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.
 
 ![Template for agreements](img/templates/agreement-template.png)
 
@@ -1445,7 +1445,7 @@ Another way of clarifying a domain is by filling out an [S3 Delegation Canvas](h
 
 **Be explicit about the expected results of agreements, activities, projects and strategies.**
 
-Agree on and record a concise description of the intended outcome. 
+Agree on and record a concise description of the intended outcome.
 
 The intended outcome can be used to define _Evaluation Criteria_ and metrics for reviewing actual outcome.
 
@@ -1493,13 +1493,13 @@ Common platforms for logbooks are Wikis (e.g. [Dokuwiki](https://www.dokuwiki.or
 
 ### Logbook Contents
 
-Content relating to the whole organization: 
+Content relating to the whole organization:
 
 -   [primary driver](glossary:primary-driver), [strategy](glossary:strategy) and organizational [values](glossary:values)
 -   organizational structure ([domains](glossary:domain) and the connections between them)
--   [agreements](glossary:agreement) 
+-   [agreements](glossary:agreement)
 
-Content relating to a specific team or [role](glossary:role): 
+Content relating to a specific team or [role](glossary:role):
 
 -   the domain description and strategy
 -   agreements (including [delegatees'](glossary:delegatee) domain descriptions, strategies and _development plans_)
@@ -1513,7 +1513,7 @@ Content relating to a specific team or [role](glossary:role):
 
 **Select a member of your team to be specifically accountable for keeping up to date records of all information the team requires.**
 
-The logbook keeper is accountable for maintaining a team's [logbook](glossary:logbook) by: 
+The logbook keeper is accountable for maintaining a team's [logbook](glossary:logbook) by:
 
 -   recording details of [agreements](glossary:agreement), [domain](glossary:domain) descriptions, _selections_, evaluation dates, minutes of meetings etc.
 -   organizing relevant information and improving the system when valuable
@@ -1537,19 +1537,19 @@ The logbook keeper is accountable for maintaining a team's [logbook](glossary:lo
 
 A governance meeting is usually:
 
--   facilitated 
--   prepared in advance 
+-   facilitated
+-   prepared in advance
 -   _timeboxed_ for a duration of 90-120 minutes
 -   scheduled every 2-4 weeks
 
-A typical governance meeting includes: 
+A typical governance meeting includes:
 
 -   opening: _check in_ with each other and attune to the objective of the meeting
--   administrative matters 
+-   administrative matters
     -   check for consent to the last meeting's minutes
     -   agree on a date for the next meeting
     -   check for any last-minute agenda items and for consent to the agenda
--   agenda items 
+-   agenda items
 -   _meeting evaluation_: reflect on your interactions, celebrate successes and share suggestions for improvement
 -   closing: check in with each other before you leave the meeting
 
@@ -1557,10 +1557,10 @@ A typical governance meeting includes:
 
 Typical agenda items include:
 
--   any short reports 
+-   any short reports
 -   evaluation of existing [agreements](glossary:agreement) due review
--   selecting people to roles 
--   new drivers requiring decisions to be made, including: 
+-   selecting people to roles
+-   new drivers requiring decisions to be made, including:
     -   _forming proposals_
     -   _making agreements_
     -   _designing domains_ and deciding how to account for them (e.g. new _roles_, _circles_, teams or _open domains_)
@@ -1583,7 +1583,7 @@ Typical agenda items include:
 
 ### Five Phases of a Retrospective Meeting
 
-1. Set the stage 
+1. Set the stage
 2. Gather data
 3. Generate insights
 4. Decide what to do
@@ -1632,10 +1632,10 @@ Many different activities for each phase can be found at [plans-for-retrospectiv
     -   include details of any prerequisites that can help attendees to prepare
     -   further agenda items may come up when hearing status reports
 
-Agenda items: 
+Agenda items:
 
 - cross domain synchronization and alignment
-- prioritization and distribution of work  
+- prioritization and distribution of work
 - responding to impediments
 
 ![Phases of a coordination meeting](img/meetings/coordination-meeting.png)
@@ -1656,11 +1656,11 @@ Agenda items:
 
 Rounds are a group facilitation technique to maintain equivalence and support effective dialogue.
 
-Be clear on the purpose and intended outcome of each round. 
+Be clear on the purpose and intended outcome of each round.
 
 Sit in a circle, begin each round with a different person, and change direction (clockwise or counterclockwise) to bring variation to who speaks first and last, and to the order of contributions.
 
-![Rounds](img/circle/rounds.png) 
+![Rounds](img/circle/rounds.png)
 
 
 ---
@@ -1689,10 +1689,10 @@ Consider selecting a facilitator for a specific term. Even an inexperienced faci
 Some considerations for successfully preparing a meeting:
 
 - clarify and communicate the [driver](glossary:driver) for, and [intended outcome](glossary:intended-outcome) of the meeting
-- decide who to invite 
+- decide who to invite
 - create an agenda
 - schedule the meeting enough in advance, so people have time to prepare
-- choose an appropriate duration for the meeting 
+- choose an appropriate duration for the meeting
 - be clear who will _facilitate the meeting_, who will take minutes and who will take care of any follow-up
 
 ### Preparing an Agenda
@@ -1701,10 +1701,10 @@ Involve people in preparing and prioritizing an agenda and send it out in advanc
 
 For each agenda item agree on:
 
-- the driver 
+- the driver
 - the intended outcome
 - the process
-- the time you want to spend on it 
+- the time you want to spend on it
 - what people need to do to prepare
 
 ### Support the Participants' Preparation
@@ -1727,13 +1727,13 @@ For each agenda item agree on:
 
 **Help people to become aware of themselves and others, and to focus, be present and engage.**
 
-To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs. 
+To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs.
 
-Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting. 
+Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting.
 
 You can also call for a group check-in during a meeting, or even choose to individually check in whenever you think this is valuable for the group.
 
-In a group check-in, allow people to pass if they choose. 
+In a group check-in, allow people to pass if they choose.
 
 When checking in, in a new setting, people can also say their name and where they are coming from, as a way to introduce themselves. (Tip: Avoid talking about function, rank etc unless there is a reason to do so.)
 
@@ -1748,7 +1748,7 @@ Reflect on interactions, celebrate successes and share suggestions for improveme
 -   reserve 5 minutes for 1 hour, and 15 minutes for a full-day workshop
 -   record learning and review it before the next meeting
 
-Short formats you can use: 
+Short formats you can use:
 
 -   more of/less of/start/stop/keep
 -   positive/critical/suggested improvements
@@ -1842,7 +1842,7 @@ Each item on a (prioritized) backlog typically contains:
 -   (the **order of work items**)
 -   **dependencies** to other work items or projects
 -   **due date** (if necessary)
--   (optional) a measure for **value** 
+-   (optional) a measure for **value**
 -   (optional) a measure for **investment** (often an estimate of time or complexity)
 
 
@@ -1870,7 +1870,7 @@ A prioritized [backlog](glossary:backlog) helps to **maintain focus** on the mos
 
 ![Visualization of a simple work process](img/workflow-and-value/simple-process.png)
 
-### Things to track: 
+### Things to track:
 
 -   **types of work items** (e.g. customer request, project tasks, reporting tasks, rework)
 -   **start date** (and **due date** if necessary)
@@ -1892,7 +1892,7 @@ A prioritized [backlog](glossary:backlog) helps to **maintain focus** on the mos
 
 Prioritize pending work items to ensure that important items are worked on first.
 
-Pulling in work prevents overloading the system, especially when _work in progress (WIP) per person or team is limited_. 
+Pulling in work prevents overloading the system, especially when _work in progress (WIP) per person or team is limited_.
 
 
 ---
@@ -2038,7 +2038,7 @@ A delegate circle may bring in other people (e.g. external experts) to help with
 
 Teams in the periphery:
 
--   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.) 
+-   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.)
 -   steward the monetary resources and steer the organization
 
 The center provides internal services to support the organization.
@@ -2070,7 +2070,7 @@ A double-linked hierarchy:
 
 ## Pattern 10.5: Service Organization
 
-**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).** 
+**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).**
 
 -   improves potential for equivalence between various entities
 -   increases cross-departmental/organizational alignment
@@ -2087,9 +2087,9 @@ A double-linked hierarchy:
 
 **Multiple constituents (organizations or projects) with a common (or similar) primary driver and structure can share learning across functional domains, align action and make high level governance decisions (e.g. overall strategy)**.
 
-Creating a fractal organization can enable a large network to rapidly respond to changing contexts. 
+Creating a fractal organization can enable a large network to rapidly respond to changing contexts.
 
-If necessary, the pattern can be repeated to connect multiple fractal organizations into one. 
+If necessary, the pattern can be repeated to connect multiple fractal organizations into one.
 
 ![Fractal Organization](img/structural-patterns/fractal-organization.png)
 
@@ -2101,7 +2101,7 @@ These [constituents](glossary:constituent) (i.e. organizations, branches, depart
 
 ### Tiers
 
-A fractal organization has at least three tiers: 
+A fractal organization has at least three tiers:
 
 - first tier: the **constituents** (i.e. organizations, branches, departments or projects)
 - second tier: **function-specific _delegate circles_** to share learning and to make and evolve agreements on behalf of function-specific domains
@@ -2187,7 +2187,7 @@ The second and third tier:
 - added and revised the brief summary for many of the patterns
 - removed bullet points in favor of full sentences in many patterns
 - lots of small improvements to grammar and language
-- included the URL to the web version of the practical guide 
+- included the URL to the web version of the practical guide
 
 **Glossary:**
 
@@ -2199,8 +2199,8 @@ The second and third tier:
 
 -   added the driver for creating Sociocracy 3.0
 -   The Seven Principles:
-    -   _The Principle of Empiricism_: removed reference to “falsification” 
-    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions” 
+    -   _The Principle of Empiricism_: removed reference to “falsification”
+    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions”
 -   _Governance, Semi-Autonomy and Self-Organization_: we refined the definitions of Governance, Operations, and Self-Organization, removed any reference to “coordination”, and clarified the distinction between governance and operations
 -   _Drivers and Domains_ - we clarified how domains can be understood in relation to organizational drivers
 
@@ -2246,10 +2246,10 @@ The second and third tier:
 - _Rounds_: improved description
 - _Transparent Salary_: added more details about fairness, and on how to develop a salary formula
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Evaluate Agreements_ to _Evaluate and Evolve Agreements_
-- _Intended Outcome_ to _Clarify Intended Outcome_ 
+- _Intended Outcome_ to _Clarify Intended Outcome_
 - _Open S3 Adoption_ to _Open Space for Change_
 - _Contracting and Accountability_ to _Contract For Successful Collaboration_
 
@@ -2287,8 +2287,8 @@ The second and third tier:
 - added Liliana David to authors
 - dropped the term "framework" (replaced with "practical guide")
 - updated order of patterns
-- added an index of all the patterns 
-- added a glossary 
+- added an index of all the patterns
+- added a glossary
 - added acknowledgments
 - various small clarifications and corrections to text and illustrations
 - updated templates for agreement and development plan
@@ -2321,7 +2321,7 @@ The second and third tier:
 - _Proposal Forming_: added criteria for selecting tuners, added step for prioritizing considerations, small clarifications
 - _Resolve Objections_: updated illustration to better reflect the process
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Backbone Organization_ to _Service Organization_
 - _Effectiveness Review_ to _Peer Review_
@@ -2362,7 +2362,7 @@ Various other formats and languages of the practical guide can be found at <http
 ## License
 
 
-"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**. 
+"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**.
 
 Basically this license grants you:
 
@@ -2371,7 +2371,7 @@ Basically this license grants you:
 3. Freedom to share copies of the work for any purpose, even commercially.
 4. Freedom to make and share remixes and other derivatives for any purpose.
 
-You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**. 
+You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**.
 
 To view the the full text of this license, visit <https://creativecommons.org/licenses/by-sa/4.0/legalcode>
 
@@ -2436,7 +2436,7 @@ I will discuss possible objections relating to S3 patterns in my intervision gro
 
 ---
 
-## Acknowledgments 
+## Acknowledgments
 
 The content of Sociocracy 3.0 reflects the accumulated experience and wisdom of contributors across generations. These people have shared a common quest: to evolve more effective, harmonious and conscious ways of collaborating together.
 
@@ -2454,7 +2454,7 @@ Gojko Adzic, Lyssa Adkins, Christopher Alexander, David J. Anderson, Ruth Andrad
 
 ---
 
-## Authors 
+## Authors
 
 We sell consulting, learning facilitation, coaching and mentoring, including but not limited to *Sociocracy 3.0*. We dedicate a part of our time and money to create free resources about *Sociocracy 3.0* as part of our ongoing commitment to make sociocracy and related ideas more accessible to the wider world.
 
@@ -2469,7 +2469,7 @@ We sell consulting, learning facilitation, coaching and mentoring, including but
 <james@thriveincollaboration.com>
 
 
-### Bernhard Bockelbrink 
+### Bernhard Bockelbrink
 
 ... is an agile coach, trainer and consultant supporting individuals, teams and organizations in navigating complex challenges and developing a culture of effective, conscious and joyful collaboration.
 
@@ -2490,7 +2490,7 @@ We sell consulting, learning facilitation, coaching and mentoring, including but
 ---
 
 
-# Glossary 
+# Glossary
 
 
 **Account for (v.):** to take the responsibility for something.

--- a/S3-practical-guide.md
+++ b/S3-practical-guide.md
@@ -79,7 +79,7 @@ Sociocracy 3.0 is:
 
 The literal meaning of the term **sociocracy**  is "rule of the companions": _socio_ — from Latin _socius_ — means "companion", or "friend", and the suffix _-cracy_ — from Ancient Greek κράτος (krátos) — means “power", or "rule”.
 
-The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
+The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
 
 A few decades later, **Lester Frank Ward**, used the word 'sociocracy' to describe the rule of people with relations with each other. Instead of having sociologists at the center, he wanted to give more power and responsibility to the individual, he imagined sociologists in a role as researchers and consultant.
 

--- a/content/src/introduction/history.md
+++ b/content/src/introduction/history.md
@@ -14,9 +14,9 @@ In 1926, the Dutch reformist educator and Quaker **Kees Boeke**, established a r
 
 During the late 1990s and early 2000s, several non-Dutch speaking people came across sociocracy, but it wasn't until 2007 when **Sharon Villines and John Buck** launched their book, "We the People", that sociocracy became widely accessible to the English speaking world, and from there has began to migrate into several other languages.
 
-Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral. 
+Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral.
 
-In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015. 
+In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile, and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015.
 
 **Liliana David** joined the team soon after and together they regularly collaborate to develop both the framework and the website.
 

--- a/content/src/introduction/history.md
+++ b/content/src/introduction/history.md
@@ -4,7 +4,7 @@
 
 The literal meaning of the term **sociocracy**  is "rule of the companions": _socio_ — from Latin _socius_ — means "companion", or "friend", and the suffix _-cracy_ — from Ancient Greek κράτος (krátos) — means “power", or "rule”.
 
-The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
+The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
 
 A few decades later, **Lester Frank Ward**, used the word 'sociocracy' to describe the rule of people with relations with each other. Instead of having sociologists at the center, he wanted to give more power and responsibility to the individual, he imagined sociologists in a role as researchers and consultant.
 

--- a/docs/agreement.md
+++ b/docs/agreement.md
@@ -10,10 +10,10 @@ Agreements are created in response to <dfn data-info="Organizational Driver: A d
 **Overall accountability** for an agreement lies with the people that make them.
 
 An agreement can include **delegation of specific responsibilities** to individuals or groups.
-   
+
 Record any **expectations** related to <dfn data-info="Deliverable: A product, service, component or material provided in response to an organizational driver.">deliverables</dfn>, behavior or resources in the context of the agreement.
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.
 
 ![Template for agreements](img/templates/agreement-template.png)
 

--- a/docs/all.md
+++ b/docs/all.md
@@ -4,17 +4,17 @@ title: Sociocracy 3.0 - A Practical Guide
 
 # Introduction
 
-## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations 
+## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations
 
 ### Effective Collaboration At Any Scale
 
-Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**. 
+Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**.
 
 S3 brings you an extensive collection of guidelines and practices (so-called “patterns”) that have proven helpful for organizations to **improve performance, alignment, fulfillment and wellbeing**.
 
 These patterns help you discover how to best reach your objectives and navigate complexity, one step at a time, **without the need for sudden radical reorganization or planning a long-term change initiative**:
 
- Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go. 
+ Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go.
 
 **Regardless of your position in the organization**, you will find patterns that are relevant and helpful for you.
 
@@ -52,7 +52,7 @@ Sociocracy 3.0 is:
 
 -   a bit of history and a brief overview of some basic concepts behind S3
 -   a description of all the patterns in S3
--   an appendix 
+-   an appendix
     -   changelog
     -   info about authors and acknowledgments
     -   the license
@@ -76,9 +76,9 @@ In 1926, the Dutch reformist educator and Quaker **Kees Boeke**, established a r
 
 During the late 1990s and early 2000s, several non-Dutch speaking people came across sociocracy, but it wasn't until 2007 when **Sharon Villines and John Buck** launched their book, "We the People", that sociocracy became widely accessible to the English speaking world, and from there has began to migrate into several other languages.
 
-Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral. 
+Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral.
 
-In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015. 
+In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile, and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015.
 
 **Liliana David** joined the team soon after and together they regularly collaborate to develop both the framework and the website.
 
@@ -103,7 +103,7 @@ We also love agile, lean, Kanban, the Core Protocols, NVC, and many other ideas 
 
 Therefore we decided to devote some of our time to develop and evolve Sociocracy, integrating it with many of these other potent ideas, to make it available and applicable to as many organizations as possible.
 
-To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability. 
+To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability.
 
 ### The Name
 
@@ -161,7 +161,7 @@ _James Priest, Bernhard Bockelbrink and Liliana David_
 
 ## Basic Concepts
 
-Before diving into the content, consider taking time to learn about some basic concepts behind S3: 
+Before diving into the content, consider taking time to learn about some basic concepts behind S3:
 
 -   What is a pattern?
 -   The Seven Principles
@@ -173,7 +173,7 @@ Before diving into the content, consider taking time to learn about some basic c
 For any terms you don't understand check out the glossary at the end.
 
 
-### Patterns 
+### Patterns
 
 _A **pattern** is a template for successfully navigating a specific context._
 
@@ -184,7 +184,7 @@ _A **pattern** is a template for successfully navigating a specific context._
 ![Patterns are grouped by topic into ten categories](img/pattern-group-headers/all-groups-dark.png)
 
 
-### The Seven Principles 
+### The Seven Principles
 
 
 Sociocracy is built on seven principles that shape organizational culture. Since the seven principles are reflected in all of the patterns, understanding these principles is helpful for adopting and paramount to adapting Sociocracy 3.0 patterns.
@@ -218,7 +218,7 @@ Every member of the organization is accountable for effectively responding to or
 Individuals are also accountable for their work, ongoing learning and development, and for supporting one another.
 
 Everyone in an organization is accountable for aligning activity with organizational values.
- 
+
 
 ### Making Sense of Organizations
 
@@ -227,7 +227,7 @@ Everyone in an organization is accountable for aligning activity with organizati
 
 _A **driver** is a person’s or a group's motive for responding to a specific situation._
 
-Drivers: 
+Drivers:
 
 -   can be used to derive goals, objectives, aims, mission, vision, purpose
 -   can change over time
@@ -285,19 +285,19 @@ While a decision of short-term consequence can easily be amended on the spot, ma
 
 Such agreements need to be documented, both to remember them and to support effective _review_, and to be communicated to people affected (who are ideally also _involved in the creation and evolution_ of those agreements).
 
-Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations: 
+Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations:
 
 _**Governance** in an organization (or a domain within it) is the act of setting objectives, and making and evolving decisions that guide people towards achieving them._
 
 _**Operations** is doing the work and organizing day to day activities within the constraints defined through governance._
 
-For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value. 
+For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value.
 
 There are many ways to distribute work and governance. Sometimes the governing body is a single person, e.g. in the case of a team lead, and sometimes it’s a group of people, e.g. in a circle where all circle members share responsibility for governance within the constraints of the domain.
 
 **Governance decisions** set constraints on activity and guide future decisions.
 
-This includes: 
+This includes:
 
 -   defining domains
 -   delegating influence to people
@@ -322,7 +322,7 @@ Depending on the constraints set by the delegator, teams have more or less licen
 # The Patterns
 
 
-## Co-Creation And Evolution 
+## Co-Creation And Evolution
 
 ###  Pattern 1.1: Respond to Organizational Drivers
 
@@ -331,7 +331,7 @@ Depending on the constraints set by the delegator, teams have more or less licen
 Responses to organizational drivers include:
 
 - direct action (operations)
-- organizing how work will be done 
+- organizing how work will be done
 - making governance decisions
 
 The response to an organizational driver is typically treated as an experiment that is evaluated and evolved over time.
@@ -375,11 +375,11 @@ A simple way to describe a driver is by explaining:
     -   the **need** of the organization in relation to this situation
     -   the **impact** of attending to that need
 
-Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision. 
+Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision.
 
 ![Describe Organizational Drivers](img/process/describe-organizational-drivers.png)
 
-#### Example: 
+#### Example:
 
 > _“The kitchen is a mess: there are no clean cups, the sink is full of dishes and it’s not possible to quickly grab a coffee and get right back to work. We need the kitchen in a usable state so we can stay focused on our work.”_
 
@@ -398,9 +398,9 @@ Describe the current situation:
 
 Explain the effect of this situation on the organization:
 
-- Clarify **why** the situation needs attention: how does it affect the organization? 
-- Be explicit about whether the effects are current or anticipated. 
-- Explain challenges, losses, opportunities or gains. 
+- Clarify **why** the situation needs attention: how does it affect the organization?
+- Be explicit about whether the effects are current or anticipated.
+- Explain challenges, losses, opportunities or gains.
 
 #### 3. Need
 
@@ -408,7 +408,7 @@ Explain the effect of this situation on the organization:
 
 Explain the need of the organization in relation to this situation:
 
-- A **need of an organization** is anything a team (or individual) requires to effectively account for a domain. 
+- A **need of an organization** is anything a team (or individual) requires to effectively account for a domain.
 - Be specific on whose need it is (“we need”, “they need”, “I need”).
 - If there’s disagreement about the need, it helps to zoom out from specific solutions and focus on what the organization is lacking in this situation.
 
@@ -426,7 +426,7 @@ Describe the impact of attending to that need:
 Aim for one or two sentences, so that the information is easy to remember and process.
 
 Besides the summary, more details about the driver may be kept in the logbook.
- 
+
 
 #### Review Drivers
 
@@ -515,7 +515,7 @@ Some helpful questions:
 
 _A **concern** is an assumption that doing something (even in the absence of objections) **might** stand in the way of (more) effective response to an organizational driver._
 
-In _Consent Decision Making_, concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).  
+In _Consent Decision Making_, concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).
 
 Bring up concerns if you consider them important and at least record them along with evaluation criteria.
 
@@ -608,7 +608,7 @@ There are many ways to co-create proposals. They typically follow a similar patt
 3. Generate ideas
 4. Design a proposal (often done by a smaller group)
 
-One way to co-create proposals is to use S3's _Proposal Forming_ pattern. 
+One way to co-create proposals is to use S3's _Proposal Forming_ pattern.
 
 ![A template for proposals](img/templates/proposal-template.png)
 
@@ -630,7 +630,7 @@ _Proposal Forming_ may also be used by an individual.
 
 #### Proposal Forming Steps
 
-**Consent to driver:** Briefly present the driver. _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_ 
+**Consent to driver:** Briefly present the driver. _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_
 
 **Deepen shared understanding of driver:** invite essential questions to understand the driver in more detail.
 
@@ -646,7 +646,7 @@ _Proposal Forming_ may also be used by an individual.
 
 #### Choosing Tuners
 
-Consider: 
+Consider:
 
 -   who should be there?
 -   who wants to be there?
@@ -684,7 +684,7 @@ A prerequisite to the selection process is a _clear description_ of the role's d
     -   proposing a nominee themselves or asking a group member
     -   inviting (some) nominees to agree who should be proposed
     -   inviting group dialogue to help reveal the strongest nominee
-7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an objection. 
+7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an objection.
 8. **Address and Resolve Objections,** beginning with any from the proposed nominee. _Objections may be resolved_ in many ways, including amending the role's domain description or by nominating someone else. When all objections are resolved, check with the (final) nominee again if they accept the role.
 9. **Celebrate:** Acknowledge reaching agreement and thank the person who will now keep the role.
 
@@ -707,7 +707,7 @@ A (small or large) group identifies and clusters drivers, to then progress quick
 
 
 
-## Peer Development 
+## Peer Development
 
 ###  Pattern 2.1: Ask For Help
 
@@ -722,7 +722,7 @@ Ask someone, "_would you be willing to help me with ..._?" The person asked acce
 
 ###  Pattern 2.2: Peer Feedback
 
-Invite a peer to give you some constructive feedback on: 
+Invite a peer to give you some constructive feedback on:
 
 -   your performance in a role
 -   your general participation and contribution
@@ -768,7 +768,7 @@ A development plan (and any accompanying recommendations for changes to the  des
 
 
 
-## Enablers Of Collaboration 
+## Enablers Of Collaboration
 
 ###  Pattern 3.1: Artful Participation
 
@@ -800,7 +800,7 @@ Artful participation:
 
 #### Artful Participation: Self-Assessment
 
--   How can I support myself and others to participate more artfully? 
+-   How can I support myself and others to participate more artfully?
 -   Where are my interactions with others unhelpful or ineffective?
 -   Which agreements do I find hard to keep? What can I do to address this?
 -   What skills can I develop, that would support me to participate more artfully?
@@ -884,14 +884,14 @@ Be accountable:
 
 
 ###  Pattern 3.6: Contract For Successful Collaboration
- 
+
 **Support successful collaboration from the start and build trust between parties by co-creating mutually beneficial and legally robust contracts.**
 
-A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies. 
+A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies.
 
 Developing shared understanding about needs and expectations is essential for successful collaboration.
 
-While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved. 
+While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved.
 
 This pattern refers to contracts relating related to collaboration around any business transaction between an organization and other parties (e.g. employees, consultants, service providers, shareholders or customers). It is especially relevant for contracts that have a significant influence on the future of an organization or one of its partners, such as:
 
@@ -948,7 +948,7 @@ Any contract can be changed at any time, provided all signatories agree. However
 
 Every contract influences the culture of the collaboration it governs, even when it appears to only describe *what* needs to be delivered:
 
-- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done 
+- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done
 - align the contract to the organizational culture (of all parties) and to legal requirements
 - build contracts that enable and encourage accountability
 
@@ -966,7 +966,7 @@ A transparent salary formula needs to suit an organization's context, and to be 
 
 Perception of fairness varies from person to person and according to context, so creating a salary formula requires developing a shared understanding of what is considered fair.
 
-When deciding (or agreeing) on a salary formula for an organization or department, consider: 
+When deciding (or agreeing) on a salary formula for an organization or department, consider:
 
 - what would be a suitable fixed subsistence guarantee
 - how to calculate compensation according to need, investment, productivity, or merit
@@ -980,7 +980,7 @@ Decide how to handle remuneration for changing roles and _develop a strategy_ fo
 ###  Pattern 3.8: Support Role
 
 **Apply the role pattern to external contractors.**
-    
+
 -   clarify and describe the driver for the _role_
 -   create a _domain description_
 -   if valuable, implement a selection process
@@ -996,7 +996,7 @@ External contractors consent to take on their role.
 Secure S3 principles and patterns in your bylaws as needed to protect **legal integrity** and **organizational culture**
 
 Consider:
-    
+
 -   consent and equivalence in decision making
 -   selection process for leadership roles
 -   organizational structure, values and principles
@@ -1005,7 +1005,7 @@ Consider:
 
 
 
-## Building Organizations 
+## Building Organizations
 
 ###  Pattern 4.1: Delegate Influence
 
@@ -1040,7 +1040,7 @@ A circle:
 -  **equivalence of circle members:**
     -   All members of a circle are equally accountable for governance of the circle's domain.
 
-![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)  
+![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)
 
 
 ###  Pattern 4.3: Role
@@ -1060,7 +1060,7 @@ A role is a simple way for an organization (or team) to delegate recurring tasks
 
 A role keeper may maintain a governance backlog, and a logbook to record and help them evolve their approach toward delivering value.
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.
 
 ![People can take responsibility for more than one role](img/illustrations/roles.png)
 
@@ -1103,7 +1103,7 @@ Representatives (a.k.a. links):
 
 **Bring together a team of equivalent people with the mandate to execute on a specific set of requirements defined by a delegator.**
 
-A helping team: 
+A helping team:
 
 -   is a way for a delegator to expand their capacity
 -   may be self-organizing, or guided by a _coordinator_ chosen by the delegator
@@ -1125,14 +1125,14 @@ Members of the helping team:
 **Intentionally account for a domain by invitation rather than assignment and request that those invited contribute when they can.**
 
 The delegator of the open domain clarifies:
- 
+
 - the primary driver, key responsibilities and constraints of the open domain
 - who is invited to contribute to the open domain
 - constraints relating to the delegator’s participation in the open domain’s governance
 
 Depending on the constraints set by the delegator, contributors may only organize and do work, or take part in governance as well.
 
-A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain. 
+A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain.
 
 ![Open Domain](img/structural-patterns/open-domain.png)
 
@@ -1148,7 +1148,7 @@ Individuals, teams and entire organizations can acknowledge interdependence and 
 
 
 
-## Bringing In S3 
+## Bringing In S3
 
 ###  Pattern 5.1: Adapt Patterns To Context
 
@@ -1224,7 +1224,7 @@ Include the people involved and affected in regular evaluation of outcomes.
 -   initiate a process of continuous improvement, e.g. through Kanban or regular _retrospectives_
 -   members of the team pull in S3 patterns as required
 -   if valuable, iteratively expand the scope of the experiment to other teams
--   intentionally look out for impediments  
+-   intentionally look out for impediments
 
 #### Waste And Continuous Improvement
 
@@ -1238,7 +1238,7 @@ Establishing a process for the ongoing elimination of waste enables natural evol
 
 
 
-## Defining Agreements 
+## Defining Agreements
 
 
 ![Any agreement or decision can be viewed as an experiment.](img/evolution/experiments.png)
@@ -1256,10 +1256,10 @@ Agreements are created in response to organizational drivers, are **regularly re
 **Overall accountability** for an agreement lies with the people that make them.
 
 An agreement can include **delegation of specific responsibilities** to individuals or groups.
-   
+
 Record any **expectations** related to deliverables, behavior or resources in the context of the agreement.
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are also treated as agreements.
 
 ![Template for agreements](img/templates/agreement-template.png)
 
@@ -1305,7 +1305,7 @@ Another way of clarifying a domain is by filling out an [S3 Delegation Canvas](h
 
 **Be explicit about the expected results of agreements, activities, projects and strategies.**
 
-Agree on and record a concise description of the intended outcome. 
+Agree on and record a concise description of the intended outcome.
 
 The intended outcome can be used to define _Evaluation Criteria_ and metrics for reviewing actual outcome.
 
@@ -1347,13 +1347,13 @@ Common platforms for logbooks are Wikis (e.g. [Dokuwiki](https://www.dokuwiki.or
 
 #### Logbook Contents
 
-Content relating to the whole organization: 
+Content relating to the whole organization:
 
 -   primary driver, strategy and organizational values
 -   organizational structure (domains and the connections between them)
--   agreements 
+-   agreements
 
-Content relating to a specific team or role: 
+Content relating to a specific team or role:
 
 -   the domain description and strategy
 -   agreements (including delegatees' domain descriptions, strategies and _development plans_)
@@ -1365,7 +1365,7 @@ Content relating to a specific team or role:
 
 **Select a member of your team to be specifically accountable for keeping up to date records of all information the team requires.**
 
-The logbook keeper is accountable for maintaining a team's logbook by: 
+The logbook keeper is accountable for maintaining a team's logbook by:
 
 -   recording details of agreements, domain descriptions, _selections_, evaluation dates, minutes of meetings etc.
 -   organizing relevant information and improving the system when valuable
@@ -1375,7 +1375,7 @@ The logbook keeper is accountable for maintaining a team's logbook by:
 
 
 
-## Focused Interactions 
+## Focused Interactions
 
 ###  Pattern 7.1: Governance Meeting
 
@@ -1383,19 +1383,19 @@ The logbook keeper is accountable for maintaining a team's logbook by:
 
 A governance meeting is usually:
 
--   facilitated 
--   prepared in advance 
+-   facilitated
+-   prepared in advance
 -   _timeboxed_ for a duration of 90-120 minutes
 -   scheduled every 2-4 weeks
 
-A typical governance meeting includes: 
+A typical governance meeting includes:
 
 -   opening: _check in_ with each other and attune to the objective of the meeting
--   administrative matters 
+-   administrative matters
     -   check for consent to the last meeting's minutes
     -   agree on a date for the next meeting
     -   check for any last-minute agenda items and for consent to the agenda
--   agenda items 
+-   agenda items
 -   _meeting evaluation_: reflect on your interactions, celebrate successes and share suggestions for improvement
 -   closing: check in with each other before you leave the meeting
 
@@ -1403,10 +1403,10 @@ A typical governance meeting includes:
 
 Typical agenda items include:
 
--   any short reports 
+-   any short reports
 -   evaluation of existing agreements due review
--   selecting people to roles 
--   new drivers requiring decisions to be made, including: 
+-   selecting people to roles
+-   new drivers requiring decisions to be made, including:
     -   _forming proposals_
     -   _making agreements_
     -   _designing domains_ and deciding how to account for them (e.g. new _roles_, _circles_, teams or _open domains_)
@@ -1427,7 +1427,7 @@ Typical agenda items include:
 
 #### Five Phases of a Retrospective Meeting
 
-1. Set the stage 
+1. Set the stage
 2. Gather data
 3. Generate insights
 4. Decide what to do
@@ -1470,17 +1470,17 @@ Many different activities for each phase can be found at [plans-for-retrospectiv
     -   include details of any prerequisites that can help attendees to prepare
     -   further agenda items may come up when hearing status reports
 
-Agenda items: 
+Agenda items:
 
 - cross domain synchronization and alignment
-- prioritization and distribution of work  
+- prioritization and distribution of work
 - responding to impediments
 
 ![Phases of a coordination meeting](img/meetings/coordination-meeting.png)
 
 
 
-## Meeting Practices 
+## Meeting Practices
 
 ###  Pattern 8.1: Rounds
 
@@ -1488,11 +1488,11 @@ Agenda items:
 
 Rounds are a group facilitation technique to maintain equivalence and support effective dialogue.
 
-Be clear on the purpose and intended outcome of each round. 
+Be clear on the purpose and intended outcome of each round.
 
 Sit in a circle, begin each round with a different person, and change direction (clockwise or counterclockwise) to bring variation to who speaks first and last, and to the order of contributions.
 
-![Rounds](img/circle/rounds.png) 
+![Rounds](img/circle/rounds.png)
 
 
 ###  Pattern 8.2: Facilitate Meetings
@@ -1517,10 +1517,10 @@ Consider selecting a facilitator for a specific term. Even an inexperienced faci
 Some considerations for successfully preparing a meeting:
 
 - clarify and communicate the driver for, and intended outcome of the meeting
-- decide who to invite 
+- decide who to invite
 - create an agenda
 - schedule the meeting enough in advance, so people have time to prepare
-- choose an appropriate duration for the meeting 
+- choose an appropriate duration for the meeting
 - be clear who will _facilitate the meeting_, who will take minutes and who will take care of any follow-up
 
 #### Preparing an Agenda
@@ -1529,10 +1529,10 @@ Involve people in preparing and prioritizing an agenda and send it out in advanc
 
 For each agenda item agree on:
 
-- the driver 
+- the driver
 - the intended outcome
 - the process
-- the time you want to spend on it 
+- the time you want to spend on it
 - what people need to do to prepare
 
 #### Support the Participants' Preparation
@@ -1553,13 +1553,13 @@ For each agenda item agree on:
 
 **Help people to become aware of themselves and others, and to focus, be present and engage.**
 
-To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs. 
+To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs.
 
-Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting. 
+Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting.
 
 You can also call for a group check-in during a meeting, or even choose to individually check in whenever you think this is valuable for the group.
 
-In a group check-in, allow people to pass if they choose. 
+In a group check-in, allow people to pass if they choose.
 
 When checking in, in a new setting, people can also say their name and where they are coming from, as a way to introduce themselves. (Tip: Avoid talking about function, rank etc unless there is a reason to do so.)
 
@@ -1572,7 +1572,7 @@ Reflect on interactions, celebrate successes and share suggestions for improveme
 -   reserve 5 minutes for 1 hour, and 15 minutes for a full-day workshop
 -   record learning and review it before the next meeting
 
-Short formats you can use: 
+Short formats you can use:
 
 -   more of/less of/start/stop/keep
 -   positive/critical/suggested improvements
@@ -1628,7 +1628,7 @@ A governance backlog contains:
 
 
 
-## Organizing Work 
+## Organizing Work
 
 ###  Pattern 9.1: Backlog
 
@@ -1656,7 +1656,7 @@ Each item on a (prioritized) backlog typically contains:
 -   (the **order of work items**)
 -   **dependencies** to other work items or projects
 -   **due date** (if necessary)
--   (optional) a measure for **value** 
+-   (optional) a measure for **value**
 -   (optional) a measure for **investment** (often an estimate of time or complexity)
 
 
@@ -1680,7 +1680,7 @@ A prioritized backlog helps to **maintain focus** on the most important items.
 
 ![Visualization of a simple work process](img/workflow-and-value/simple-process.png)
 
-#### Things to track: 
+#### Things to track:
 
 -   **types of work items** (e.g. customer request, project tasks, reporting tasks, rework)
 -   **start date** (and **due date** if necessary)
@@ -1700,7 +1700,7 @@ A prioritized backlog helps to **maintain focus** on the most important items.
 
 Prioritize pending work items to ensure that important items are worked on first.
 
-Pulling in work prevents overloading the system, especially when _work in progress (WIP) per person or team is limited_. 
+Pulling in work prevents overloading the system, especially when _work in progress (WIP) per person or team is limited_.
 
 
 ###  Pattern 9.5: Limit Work in Progress
@@ -1770,7 +1770,7 @@ Several coordinators may collaborate to synchronize work across multiple domains
 Instead of selecting a coordinator, a team may choose to self-organize.
 
 
-## Organizational Structure 
+## Organizational Structure
 
 
 Organizational structure is the actual arrangement of domains and their connections. It reflects where power to influence is located, and the channels through which information and influence flow.
@@ -1825,7 +1825,7 @@ A delegate circle may bring in other people (e.g. external experts) to help with
 
 Teams in the periphery:
 
--   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.) 
+-   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.)
 -   steward the monetary resources and steer the organization
 
 The center provides internal services to support the organization.
@@ -1853,7 +1853,7 @@ A double-linked hierarchy:
 
 ###  Pattern 10.5: Service Organization
 
-**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).** 
+**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).**
 
 -   improves potential for equivalence between various entities
 -   increases cross-departmental/organizational alignment
@@ -1868,9 +1868,9 @@ A double-linked hierarchy:
 
 **Multiple constituents (organizations or projects) with a common (or similar) primary driver and structure can share learning across functional domains, align action and make high level governance decisions (e.g. overall strategy)**.
 
-Creating a fractal organization can enable a large network to rapidly respond to changing contexts. 
+Creating a fractal organization can enable a large network to rapidly respond to changing contexts.
 
-If necessary, the pattern can be repeated to connect multiple fractal organizations into one. 
+If necessary, the pattern can be repeated to connect multiple fractal organizations into one.
 
 ![Fractal Organization](img/structural-patterns/fractal-organization.png)
 
@@ -1882,7 +1882,7 @@ These constituents (i.e. organizations, branches, departments or projects) need 
 
 #### Tiers
 
-A fractal organization has at least three tiers: 
+A fractal organization has at least three tiers:
 
 - first tier: the **constituents** (i.e. organizations, branches, departments or projects)
 - second tier: **function-specific _delegate circles_** to share learning and to make and evolve agreements on behalf of function-specific domains
@@ -1970,7 +1970,7 @@ The second and third tier:
 - added and revised the brief summary for many of the patterns
 - removed bullet points in favor of full sentences in many patterns
 - lots of small improvements to grammar and language
-- included the URL to the web version of the practical guide 
+- included the URL to the web version of the practical guide
 
 **Glossary:**
 
@@ -1982,8 +1982,8 @@ The second and third tier:
 
 -   added the driver for creating Sociocracy 3.0
 -   The Seven Principles:
-    -   _The Principle of Empiricism_: removed reference to “falsification” 
-    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions” 
+    -   _The Principle of Empiricism_: removed reference to “falsification”
+    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions”
 -   _Governance, Semi-Autonomy and Self-Organization_: we refined the definitions of Governance, Operations, and Self-Organization, removed any reference to “coordination”, and clarified the distinction between governance and operations
 -   _Drivers and Domains_ - we clarified how domains can be understood in relation to organizational drivers
 
@@ -2029,10 +2029,10 @@ The second and third tier:
 - _Rounds_: improved description
 - _Transparent Salary_: added more details about fairness, and on how to develop a salary formula
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Evaluate Agreements_ to _Evaluate and Evolve Agreements_
-- _Intended Outcome_ to _Clarify Intended Outcome_ 
+- _Intended Outcome_ to _Clarify Intended Outcome_
 - _Open S3 Adoption_ to _Open Space for Change_
 - _Contracting and Accountability_ to _Contract For Successful Collaboration_
 
@@ -2070,8 +2070,8 @@ The second and third tier:
 - added Liliana David to authors
 - dropped the term "framework" (replaced with "practical guide")
 - updated order of patterns
-- added an index of all the patterns 
-- added a glossary 
+- added an index of all the patterns
+- added a glossary
 - added acknowledgments
 - various small clarifications and corrections to text and illustrations
 - updated templates for agreement and development plan
@@ -2104,7 +2104,7 @@ The second and third tier:
 - _Proposal Forming_: added criteria for selecting tuners, added step for prioritizing considerations, small clarifications
 - _Resolve Objections_: updated illustration to better reflect the process
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Backbone Organization_ to _Service Organization_
 - _Effectiveness Review_ to _Peer Review_
@@ -2141,7 +2141,7 @@ Various other formats and languages of the practical guide can be found at <http
 ## License
 
 
-"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**. 
+"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**.
 
 Basically this license grants you:
 
@@ -2150,7 +2150,7 @@ Basically this license grants you:
 3. Freedom to share copies of the work for any purpose, even commercially.
 4. Freedom to make and share remixes and other derivatives for any purpose.
 
-You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**. 
+You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**.
 
 To view the the full text of this license, visit <https://creativecommons.org/licenses/by-sa/4.0/legalcode>
 
@@ -2211,7 +2211,7 @@ I will make any S3 resources I adapt or create available under a Creative Common
 I will discuss possible objections relating to S3 patterns in my intervision group, and pass to S3 developers if I believe they qualify.
 
 
-## Acknowledgments 
+## Acknowledgments
 
 The content of Sociocracy 3.0 reflects the accumulated experience and wisdom of contributors across generations. These people have shared a common quest: to evolve more effective, harmonious and conscious ways of collaborating together.
 
@@ -2227,7 +2227,7 @@ Gojko Adzic, Lyssa Adkins, Christopher Alexander, David J. Anderson, Ruth Andrad
 
 
 
-## Authors 
+## Authors
 
 We sell consulting, learning facilitation, coaching and mentoring, including but not limited to *Sociocracy 3.0*. We dedicate a part of our time and money to create free resources about *Sociocracy 3.0* as part of our ongoing commitment to make sociocracy and related ideas more accessible to the wider world.
 
@@ -2242,7 +2242,7 @@ We sell consulting, learning facilitation, coaching and mentoring, including but
 <james@thriveincollaboration.com>
 
 
-### Bernhard Bockelbrink 
+### Bernhard Bockelbrink
 
 ... is an agile coach, trainer and consultant supporting individuals, teams and organizations in navigating complex challenges and developing a culture of effective, conscious and joyful collaboration.
 
@@ -2262,7 +2262,7 @@ We sell consulting, learning facilitation, coaching and mentoring, including but
 
 
 
-## Glossary 
+## Glossary
 
 
 **Account for (v.):** to take the responsibility for something.

--- a/docs/all.md
+++ b/docs/all.md
@@ -66,7 +66,7 @@ Sociocracy 3.0 is:
 
 The literal meaning of the term **sociocracy**  is "rule of the companions": _socio_ — from Latin _socius_ — means "companion", or "friend", and the suffix _-cracy_ — from Ancient Greek κράτος (krátos) — means “power", or "rule”.
 
-The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
+The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
 
 A few decades later, **Lester Frank Ward**, used the word 'sociocracy' to describe the rule of people with relations with each other. Instead of having sociologists at the center, he wanted to give more power and responsibility to the individual, he imagined sociologists in a role as researchers and consultant.
 

--- a/docs/artful-participation.md
+++ b/docs/artful-participation.md
@@ -31,7 +31,7 @@ Artful participation:
 
 ### Artful Participation: Self-Assessment
 
--   How can I support myself and others to participate more artfully? 
+-   How can I support myself and others to participate more artfully?
 -   Where are my interactions with others unhelpful or ineffective?
 -   Which agreements do I find hard to keep? What can I do to address this?
 -   What skills can I develop, that would support me to participate more artfully?

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -27,7 +27,7 @@ Each item on a (prioritized) backlog typically contains:
 -   (the **order of work items**)
 -   **dependencies** to other work items or projects
 -   **due date** (if necessary)
--   (optional) a measure for **value** 
+-   (optional) a measure for **value**
 -   (optional) a measure for **investment** (often an estimate of time or complexity)
 
 

--- a/docs/bylaws.md
+++ b/docs/bylaws.md
@@ -6,7 +6,7 @@ title: "Bylaws"
 Secure S3 principles and patterns in your bylaws as needed to protect **legal integrity** and **organizational culture**
 
 Consider:
-    
+
 -   consent and equivalence in decision making
 -   selection process for leadership roles
 -   organizational structure, <dfn data-info="Values: Valued principles that guide behavior. Not to be confused with &quot;value&quot; (singular) in the context of a driver.">values</dfn> and <dfn data-info="Principle: A basic idea or rule that guides behavior, or explains or controls how something happens or works.">principles</dfn>

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -61,7 +61,7 @@ title: "Changelog"
 - added and revised the brief summary for many of the patterns
 - removed bullet points in favor of full sentences in many patterns
 - lots of small improvements to grammar and language
-- included the URL to the web version of the practical guide 
+- included the URL to the web version of the practical guide
 
 **Glossary:**
 
@@ -73,8 +73,8 @@ title: "Changelog"
 
 -   added the driver for creating Sociocracy 3.0
 -   The Seven Principles:
-    -   _The Principle of Empiricism_: removed reference to “falsification” 
-    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions” 
+    -   _The Principle of Empiricism_: removed reference to “falsification”
+    -   _The Principle of Consent_ is now explained more clearly as “Raise, seek-out and resolve objections to decisions and actions”
 -   _Governance, Semi-Autonomy and Self-Organization_: we refined the definitions of Governance, Operations, and Self-Organization, removed any reference to “coordination”, and clarified the distinction between governance and operations
 -   _Drivers and Domains_ - we clarified how domains can be understood in relation to organizational drivers
 
@@ -120,10 +120,10 @@ title: "Changelog"
 - [Rounds](rounds.html): improved description
 - [Transparent Salary](transparent-salary.html): added more details about fairness, and on how to develop a salary formula
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Evaluate Agreements_ to _Evaluate and Evolve Agreements_
-- _Intended Outcome_ to _Clarify Intended Outcome_ 
+- _Intended Outcome_ to _Clarify Intended Outcome_
 - _Open S3 Adoption_ to _Open Space for Change_
 - _Contracting and Accountability_ to _Contract For Successful Collaboration_
 
@@ -161,8 +161,8 @@ title: "Changelog"
 - added Liliana David to authors
 - dropped the term "framework" (replaced with "practical guide")
 - updated order of patterns
-- added an index of all the patterns 
-- added a glossary 
+- added an index of all the patterns
+- added a glossary
 - added acknowledgments
 - various small clarifications and corrections to text and illustrations
 - updated templates for agreement and development plan
@@ -195,7 +195,7 @@ title: "Changelog"
 - _Proposal Forming_: added criteria for selecting tuners, added step for prioritizing considerations, small clarifications
 - _Resolve Objections_: updated illustration to better reflect the process
 
-**Renamed Patterns:** 
+**Renamed Patterns:**
 
 - _Backbone Organization_ to _Service Organization_
 - _Effectiveness Review_ to _Peer Review_

--- a/docs/check-in.md
+++ b/docs/check-in.md
@@ -5,13 +5,13 @@ title: "Check In"
 
 **Help people to become aware of themselves and others, and to focus, be present and engage.**
 
-To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs. 
+To check in, briefly disclose something about what’s up for you and how you are, revealing thoughts, feelings, distractions or needs.
 
-Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting. 
+Checking in may take the form of an opening or closing round in a group meeting, or just a brief exchange in a 1:1 meeting.
 
 You can also call for a group check-in during a meeting, or even choose to individually check in whenever you think this is valuable for the group.
 
-In a group check-in, allow people to pass if they choose. 
+In a group check-in, allow people to pass if they choose.
 
 When checking in, in a new setting, people can also say their name and where they are coming from, as a way to introduce themselves. (Tip: Avoid talking about function, rank etc unless there is a reason to do so.)
 

--- a/docs/circle.md
+++ b/docs/circle.md
@@ -19,7 +19,7 @@ A circle:
 -  **equivalence of circle members:**
     -   All members of a circle are equally accountable for <dfn data-info="Governance: The act of setting objectives, and making and evolving decisions that guide people towards achieving them.">governance</dfn> of the circle's domain.
 
-![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)  
+![All members of a circle are equally accountable for governance of the circle's domain](img/circle/circle.png)
 
 
 [&#9654; Role](role.html)<br/>[&#9664; Delegate Influence](delegate-influence.html)<br/>[&#9650; Building Organizations](building-organizations.html)

--- a/docs/clarify-intended-outcome.md
+++ b/docs/clarify-intended-outcome.md
@@ -5,7 +5,7 @@ title: "Clarify Intended Outcome"
 
 **Be explicit about the expected results of agreements, activities, projects and strategies.**
 
-Agree on and record a concise description of the intended outcome. 
+Agree on and record a concise description of the intended outcome.
 
 The intended outcome can be used to define [Evaluation Criteria](evaluation-criteria.html) and metrics for reviewing actual outcome.
 

--- a/docs/co-create-proposals.md
+++ b/docs/co-create-proposals.md
@@ -12,7 +12,7 @@ There are many ways to co-create proposals. They typically follow a similar patt
 3. Generate ideas
 4. Design a proposal (often done by a smaller group)
 
-One way to co-create proposals is to use S3's [Proposal Forming](proposal-forming.html) pattern. 
+One way to co-create proposals is to use S3's [Proposal Forming](proposal-forming.html) pattern.
 
 ![A template for proposals](img/templates/proposal-template.png)
 

--- a/docs/continuous-improvement-of-work-process.md
+++ b/docs/continuous-improvement-of-work-process.md
@@ -10,7 +10,7 @@ title: "Continuous Improvement Of Work Process"
 -   initiate a process of continuous improvement, e.g. through Kanban or regular [retrospectives](retrospective.html)
 -   members of the team pull in S3 patterns as required
 -   if valuable, iteratively expand the scope of the experiment to other teams
--   intentionally look out for impediments  
+-   intentionally look out for impediments
 
 ### Waste And Continuous Improvement
 

--- a/docs/contract-for-successful-collaboration.md
+++ b/docs/contract-for-successful-collaboration.md
@@ -2,14 +2,14 @@
 title: "Contract For Successful Collaboration"
 ---
 
- 
+
 **Support successful collaboration from the start and build trust between parties by co-creating mutually beneficial and legally robust contracts.**
 
-A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies. 
+A **contract** is a body of promises that two or more parties agree to make legally binding, i.e if those promises are violated, the injured party gains access to legal (or alternative) remedies.
 
 Developing shared understanding about needs and expectations is essential for successful collaboration.
 
-While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved. 
+While negotiating and agreeing on a contract, model the culture of collaboration you want to achieve, and build a positive relationship with the other parties involved.
 
 This pattern refers to contracts relating related to collaboration around any business transaction between an organization and other parties (e.g. employees, consultants, service providers, shareholders or customers). It is especially relevant for contracts that have a significant influence on the future of an organization or one of its partners, such as:
 
@@ -66,7 +66,7 @@ Any contract can be changed at any time, provided all signatories agree. However
 
 Every contract influences the culture of the collaboration it governs, even when it appears to only describe *what* needs to be delivered:
 
-- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done 
+- intentionally create the culture of collaboration you want to see by including expectations on *how* things should be done
 - align the contract to the organizational culture (of all parties) and to legal requirements
 - build contracts that enable and encourage accountability
 

--- a/docs/coordination-meeting.md
+++ b/docs/coordination-meeting.md
@@ -10,10 +10,10 @@ title: "Coordination Meeting"
     -   include details of any prerequisites that can help attendees to prepare
     -   further agenda items may come up when hearing status reports
 
-Agenda items: 
+Agenda items:
 
 - cross domain synchronization and alignment
-- prioritization and distribution of work  
+- prioritization and distribution of work
 - responding to impediments
 
 ![Phases of a coordination meeting](img/meetings/coordination-meeting.png)

--- a/docs/describe-organizational-drivers.md
+++ b/docs/describe-organizational-drivers.md
@@ -16,11 +16,11 @@ A simple way to describe a driver is by explaining:
     -   the **need** of the organization in relation to this situation
     -   the **impact** of attending to that need
 
-Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision. 
+Create a brief but comprehensive summary containing just enough information to clearly communicate the need for an action or a decision.
 
 ![Describe Organizational Drivers](img/process/describe-organizational-drivers.png)
 
-### Example: 
+### Example:
 
 > _“The kitchen is a mess: there are no clean cups, the sink is full of dishes and it’s not possible to quickly grab a coffee and get right back to work. We need the kitchen in a usable state so we can stay focused on our work.”_
 
@@ -39,9 +39,9 @@ Describe the current situation:
 
 Explain the effect of this situation on the organization:
 
-- Clarify **why** the situation needs attention: how does it affect the organization? 
-- Be explicit about whether the effects are current or anticipated. 
-- Explain challenges, losses, opportunities or gains. 
+- Clarify **why** the situation needs attention: how does it affect the organization?
+- Be explicit about whether the effects are current or anticipated.
+- Explain challenges, losses, opportunities or gains.
 
 ### 3. Need
 
@@ -49,7 +49,7 @@ Explain the effect of this situation on the organization:
 
 Explain the <dfn data-info="Need: The lack of something wanted or deemed necessary (a requirement).">need</dfn> of the organization in relation to this situation:
 
-- A **need of an organization** is anything a team (or individual) requires to effectively account for a <dfn data-info="Domain: A distinct area of influence, activity and decision making within an organization.">domain</dfn>. 
+- A **need of an organization** is anything a team (or individual) requires to effectively account for a <dfn data-info="Domain: A distinct area of influence, activity and decision making within an organization.">domain</dfn>.
 - Be specific on whose need it is (“we need”, “they need”, “I need”).
 - If there’s disagreement about the need, it helps to zoom out from specific solutions and focus on what the organization is lacking in this situation.
 
@@ -67,7 +67,7 @@ Describe the impact of attending to that need:
 Aim for one or two sentences, so that the information is easy to remember and process.
 
 Besides the summary, more details about the driver may be kept in the logbook.
- 
+
 
 ### Review Drivers
 

--- a/docs/evaluate-meetings.md
+++ b/docs/evaluate-meetings.md
@@ -10,7 +10,7 @@ Reflect on interactions, celebrate successes and share suggestions for improveme
 -   reserve 5 minutes for 1 hour, and 15 minutes for a full-day workshop
 -   record learning and review it before the next meeting
 
-Short formats you can use: 
+Short formats you can use:
 
 -   more of/less of/start/stop/keep
 -   positive/critical/suggested improvements

--- a/docs/fractal-organization.md
+++ b/docs/fractal-organization.md
@@ -5,9 +5,9 @@ title: "Fractal Organization"
 
 **Multiple constituents (organizations or projects) with a common (or similar) primary driver and structure can share learning across functional domains, align action and make high level governance decisions (e.g. overall strategy)**.
 
-Creating a fractal organization can enable a large network to rapidly respond to changing contexts. 
+Creating a fractal organization can enable a large network to rapidly respond to changing contexts.
 
-If necessary, the pattern can be repeated to connect multiple fractal organizations into one. 
+If necessary, the pattern can be repeated to connect multiple fractal organizations into one.
 
 ![Fractal Organization](img/structural-patterns/fractal-organization.png)
 
@@ -19,7 +19,7 @@ These <dfn data-info="Constituent: A team (e.g. a circle, team, department, bran
 
 ### Tiers
 
-A fractal organization has at least three tiers: 
+A fractal organization has at least three tiers:
 
 - first tier: the **constituents** (i.e. organizations, branches, departments or projects)
 - second tier: **function-specific [delegate circles](delegate-circle.html)** to share learning and to make and evolve agreements on behalf of function-specific domains

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,5 +1,5 @@
 ---
-title: Glossary 
+title: Glossary
 ---
 
 **Account for (v.):** to take the responsibility for something.

--- a/docs/governance-meeting.md
+++ b/docs/governance-meeting.md
@@ -7,19 +7,19 @@ title: "Governance Meeting"
 
 A governance meeting is usually:
 
--   facilitated 
--   prepared in advance 
+-   facilitated
+-   prepared in advance
 -   [timeboxed](timebox-activities.html) for a duration of 90-120 minutes
 -   scheduled every 2-4 weeks
 
-A typical governance meeting includes: 
+A typical governance meeting includes:
 
 -   opening: [check in](check-in.html) with each other and attune to the objective of the meeting
--   administrative matters 
+-   administrative matters
     -   check for consent to the last meeting's minutes
     -   agree on a date for the next meeting
     -   check for any last-minute agenda items and for consent to the agenda
--   agenda items 
+-   agenda items
 -   [meeting evaluation](evaluate-meetings.html): reflect on your interactions, celebrate successes and share suggestions for improvement
 -   closing: check in with each other before you leave the meeting
 
@@ -27,10 +27,10 @@ A typical governance meeting includes:
 
 Typical agenda items include:
 
--   any short reports 
+-   any short reports
 -   evaluation of existing <dfn data-info="Agreement: An agreed upon guideline, process, protocol or policy designed to guide the flow of value.">agreements</dfn> due review
--   selecting people to roles 
--   new drivers requiring decisions to be made, including: 
+-   selecting people to roles
+-   new drivers requiring decisions to be made, including:
     -   [forming proposals](co-create-proposals.html)
     -   [making agreements](consent-decision-making.html)
     -   [designing domains](clarify-domains.html) and deciding how to account for them (e.g. new [roles](role.html), [circles](circle.html), teams or [open domains](open-domain.html))

--- a/docs/helping-team.md
+++ b/docs/helping-team.md
@@ -5,7 +5,7 @@ title: "Helping Team"
 
 **Bring together a team of equivalent people with the mandate to execute on a specific set of requirements defined by a delegator.**
 
-A helping team: 
+A helping team:
 
 -   is a way for a <dfn data-info="Delegator: An individual or group delegating a domain to other(s) to be accountable for.">delegator</dfn> to expand their capacity
 -   may be self-organizing, or guided by a [coordinator](coordinator.html) chosen by the delegator

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The official description of Sociocracy 3.0: All patterns, the Seven Principles a
 
 Start with the [&#9654; introduction](introduction.html), which explains what S3 is all about, and what it can bring to your organization. At the end of the introduction, you will find a guided tour through all the patterns, just follow the links at the bottom of the page. Refer to the [&#9654; glossary](glossary.html) for terms you are not familiar with. You can also select a specific pattern from the [&#9654;pattern index](pattern-index.html), or browse the patterns groups below.
 
-This guide is also available in other languages and formats, see the [S3 resources page ](https://sociocracy30.org/resources) for a complete list. 
+This guide is also available in other languages and formats, see the [S3 resources page ](https://sociocracy30.org/resources) for a complete list.
 
 For further information about Sociocracy 3.0 and more free resources check out <http://sociocracy30.org>
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,17 +3,17 @@ title: Introduction
 ---
 
 
-## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations 
+## Sociocracy 3.0 - A Practical Guide For Evolving Agile and Resilient Organizations
 
 ### Effective Collaboration At Any Scale
 
-Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**. 
+Sociocracy 3.0 — **a.k.a. “S3”** — is a practical guide for evolving agile and resilient organizations of any size, from small start-ups to large international networks and nationwide, multi-agency collaboration. It provides for a coherent way for growing organizational integrity and **developing a sociocratic and agile mindset**.
 
 S3 brings you an extensive collection of guidelines and practices (so-called “patterns”) that have proven helpful for organizations to **improve performance, alignment, fulfillment and wellbeing**.
 
 These patterns help you discover how to best reach your objectives and navigate complexity, one step at a time, **without the need for sudden radical reorganization or planning a long-term change initiative**:
 
- Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go. 
+ Simply start with your area of greatest need, select one or more patterns to try, **move at your own pace** and develop skills as you go.
 
 **Regardless of your position in the organization**, you will find patterns that are relevant and helpful for you.
 
@@ -51,7 +51,7 @@ Sociocracy 3.0 is:
 
 -   a bit of history and a brief overview of some basic concepts behind S3
 -   a description of all the patterns in S3
--   an appendix 
+-   an appendix
     -   changelog
     -   info about authors and acknowledgments
     -   the license
@@ -74,9 +74,9 @@ In 1926, the Dutch reformist educator and Quaker **Kees Boeke**, established a r
 
 During the late 1990s and early 2000s, several non-Dutch speaking people came across sociocracy, but it wasn't until 2007 when **Sharon Villines and John Buck** launched their book, "We the People", that sociocracy became widely accessible to the English speaking world, and from there has began to migrate into several other languages.
 
-Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral. 
+Sociocracy has proven to be effective for many organizations and communities around the world, but it has yet to become viral.
 
-In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015. 
+In 2014 **James Priest and Bernhard Bockelbrink** came together to co-create a body of Creative Commons licensed learning resources, synthesizing ideas from Sociocracy, Agile, and Lean. They discovered that organizations of all sizes need a flexible menu of practices and structures – appropriate for their specific context – that enable the evolution of a sociocratic and agile mindset to achieve greater effectiveness, alignment, fulfillment and wellbeing. The first version of **Sociocracy 3.0.** was launched in March 2015.
 
 **Liliana David** joined the team soon after and together they regularly collaborate to develop both the framework and the website.
 
@@ -100,7 +100,7 @@ We also love agile, lean, Kanban, the Core Protocols, NVC, and many other ideas 
 
 Therefore we decided to devote some of our time to develop and evolve Sociocracy, integrating it with many of these other potent ideas, to make it available and applicable to as many organizations as possible.
 
-To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability. 
+To this end, we recognize the value of a strong identity, a radically different way of distribution, and of adapting the *Sociocratic Circle Organization Method* to improve its applicability.
 
 ### The Name
 
@@ -157,7 +157,7 @@ _James Priest, Bernhard Bockelbrink and Liliana David_
 
 ## Basic Concepts
 
-Before diving into the content, consider taking time to learn about some basic concepts behind S3: 
+Before diving into the content, consider taking time to learn about some basic concepts behind S3:
 
 -   What is a pattern?
 -   The Seven Principles
@@ -168,7 +168,7 @@ Before diving into the content, consider taking time to learn about some basic c
 
 For any terms you don't understand check out the glossary at the end.
 
-### Patterns 
+### Patterns
 
 _A **pattern** is a template for successfully navigating a specific context._
 
@@ -178,7 +178,7 @@ _A **pattern** is a template for successfully navigating a specific context._
 
 ![Patterns are grouped by topic into ten categories](img/pattern-group-headers/all-groups-dark.png)
 
-### The Seven Principles 
+### The Seven Principles
 
 
 Sociocracy is built on seven principles that shape organizational culture. Since the seven principles are reflected in all of the patterns, understanding these principles is helpful for adopting and paramount to adapting Sociocracy 3.0 patterns.
@@ -212,14 +212,14 @@ Every member of the organization is accountable for effectively responding to or
 Individuals are also accountable for their work, ongoing learning and development, and for supporting one another.
 
 Everyone in an organization is accountable for aligning activity with organizational values.
- 
+
 ### Making Sense of Organizations
 
 #### Drivers
 
 _A **driver** is a person’s or a group's motive for responding to a specific situation._
 
-Drivers: 
+Drivers:
 
 -   can be used to derive goals, objectives, aims, mission, vision, purpose
 -   can change over time
@@ -275,19 +275,19 @@ While a decision of short-term consequence can easily be amended on the spot, ma
 
 Such agreements need to be documented, both to remember them and to support effective [review](evaluate-and-evolve-agreements.html), and to be communicated to people affected (who are ideally also [involved in the creation and evolution](those-affected-decide.html) of those agreements).
 
-Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations: 
+Therefore it’s valuable to distinguish between two categories of activities in an organization, one of which we refer to as governance, and the other as operations:
 
 _**Governance** in an organization (or a domain within it) is the act of setting objectives, and making and evolving decisions that guide people towards achieving them._
 
 _**Operations** is doing the work and organizing day to day activities within the constraints defined through governance._
 
-For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value. 
+For each domain in an organization there is a _governing body_: people with a mandate to make and evolve agreements which govern how the people doing the work in that domain create value.
 
 There are many ways to distribute work and governance. Sometimes the governing body is a single person, e.g. in the case of a team lead, and sometimes it’s a group of people, e.g. in a circle where all circle members share responsibility for governance within the constraints of the domain.
 
 **Governance decisions** set constraints on activity and guide future decisions.
 
-This includes: 
+This includes:
 
 -   defining domains
 -   delegating influence to people

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -64,7 +64,7 @@ Sociocracy 3.0 is:
 
 The literal meaning of the term **sociocracy**  is "rule of the companions": _socio_ — from Latin _socius_ — means "companion", or "friend", and the suffix _-cracy_ — from Ancient Greek κράτος (krátos) — means “power", or "rule”.
 
-The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
+The word sociocracy can be traced back to 1851, when **Auguste Comte** suggested applying a scientific approach to society: states would be governed by a body of scientists who are experts on society (which he termed "sociologists"). In his opinion, this future, although not yet achievable, would be inevitable.
 
 A few decades later, **Lester Frank Ward**, used the word 'sociocracy' to describe the rule of people with relations with each other. Instead of having sociologists at the center, he wanted to give more power and responsibility to the individual, he imagined sociologists in a role as researchers and consultant.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -4,7 +4,7 @@ title: "License"
 
 
 
-"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**. 
+"Sociocracy 3.0 - A Practical Guide"  by Bernhard Bockelbrink, James Priest and Liliana David is licensed under a **Creative Commons Attribution-ShareAlike 4.0 International License**, which is a **Free Culture License**.
 
 Basically this license grants you:
 
@@ -13,7 +13,7 @@ Basically this license grants you:
 3. Freedom to share copies of the work for any purpose, even commercially.
 4. Freedom to make and share remixes and other derivatives for any purpose.
 
-You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**. 
+You need to **attribute the original creator of the materials**, and **all derivatives need to be shared under the same license**.
 
 To view the the full text of this license, visit <https://creativecommons.org/licenses/by-sa/4.0/legalcode>
 

--- a/docs/logbook-keeper.md
+++ b/docs/logbook-keeper.md
@@ -5,7 +5,7 @@ title: "Logbook Keeper"
 
 **Select a member of your team to be specifically accountable for keeping up to date records of all information the team requires.**
 
-The logbook keeper is accountable for maintaining a team's <dfn data-info="Logbook: A (digital) system to store all information relevant for running an organization.">logbook</dfn> by: 
+The logbook keeper is accountable for maintaining a team's <dfn data-info="Logbook: A (digital) system to store all information relevant for running an organization.">logbook</dfn> by:
 
 -   recording details of <dfn data-info="Agreement: An agreed upon guideline, process, protocol or policy designed to guide the flow of value.">agreements</dfn>, <dfn data-info="Domain: A distinct area of influence, activity and decision making within an organization.">domain</dfn> descriptions, [selections](role-selection.html), evaluation dates, minutes of meetings etc.
 -   organizing relevant information and improving the system when valuable

--- a/docs/logbook.md
+++ b/docs/logbook.md
@@ -11,13 +11,13 @@ Common platforms for logbooks are Wikis (e.g. [Dokuwiki](https://www.dokuwiki.or
 
 ### Logbook Contents
 
-Content relating to the whole organization: 
+Content relating to the whole organization:
 
 -   <dfn data-info="Primary Driver: The primary driver for a domain is the main driver that people who account for that domain respond to.">primary driver</dfn>, <dfn data-info="Strategy: A high level approach for how people will create value to successfully account for a domain.">strategy</dfn> and organizational <dfn data-info="Values: Valued principles that guide behavior. Not to be confused with &quot;value&quot; (singular) in the context of a driver.">values</dfn>
 -   organizational structure (<dfn data-info="Domain: A distinct area of influence, activity and decision making within an organization.">domains</dfn> and the connections between them)
--   <dfn data-info="Agreement: An agreed upon guideline, process, protocol or policy designed to guide the flow of value.">agreements</dfn> 
+-   <dfn data-info="Agreement: An agreed upon guideline, process, protocol or policy designed to guide the flow of value.">agreements</dfn>
 
-Content relating to a specific team or <dfn data-info="Role: A domain that is delegated to an individual.">role</dfn>: 
+Content relating to a specific team or <dfn data-info="Role: A domain that is delegated to an individual.">role</dfn>:
 
 -   the domain description and strategy
 -   agreements (including <dfn data-info="Delegatee: An individual or group accepting accountability for a domain delegated to them.">delegatees'</dfn> domain descriptions, strategies and [development plans](development-plan.html))

--- a/docs/objection.md
+++ b/docs/objection.md
@@ -56,7 +56,7 @@ Some helpful questions:
 
 _A **concern** is an assumption that doing something (even in the absence of objections) **might** stand in the way of (more) effective response to an organizational driver._
 
-In [Consent Decision Making](consent-decision-making.html), concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).  
+In [Consent Decision Making](consent-decision-making.html), concerns can inform ways to further evolve agreements (including evaluation criteria and frequency of evaluation).
 
 Bring up concerns if you consider them important and at least record them along with evaluation criteria.
 

--- a/docs/open-domain.md
+++ b/docs/open-domain.md
@@ -7,14 +7,14 @@ title: "Open Domain"
 **Intentionally account for a domain by invitation rather than assignment and request that those invited contribute when they can.**
 
 The <dfn data-info="Delegator: An individual or group delegating a domain to other(s) to be accountable for.">delegator</dfn> of the open domain clarifies:
- 
+
 - the <dfn data-info="Primary Driver: The primary driver for a domain is the main driver that people who account for that domain respond to.">primary driver</dfn>, key responsibilities and constraints of the open domain
 - who is invited to contribute to the open domain
 - constraints relating to the delegator’s participation in the open domain’s <dfn data-info="Governance: The act of setting objectives, and making and evolving decisions that guide people towards achieving them.">governance</dfn>
 
 Depending on the constraints set by the delegator, contributors may only <dfn data-info="Operations: Doing the work and organizing day to day activities within the constraints defined through governance.">organize and do work</dfn>, or take part in governance as well.
 
-A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain. 
+A delegator is accountable for conducting regular reviews to support effectiveness of work and any decision making done in an open domain.
 
 ![Open Domain](img/structural-patterns/open-domain.png)
 

--- a/docs/peach-organization.md
+++ b/docs/peach-organization.md
@@ -7,7 +7,7 @@ title: "Peach Organization"
 
 Teams in the periphery:
 
--   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.) 
+-   deliver value in direct exchange with the outside world (customers, partners, communities, municipalities etc.)
 -   steward the monetary resources and steer the organization
 
 The center provides internal services to support the organization.

--- a/docs/peer-feedback.md
+++ b/docs/peer-feedback.md
@@ -3,7 +3,7 @@ title: "Peer Feedback"
 ---
 
 
-Invite a peer to give you some constructive feedback on: 
+Invite a peer to give you some constructive feedback on:
 
 -   your performance in a role
 -   your general participation and contribution

--- a/docs/prepare-for-meetings.md
+++ b/docs/prepare-for-meetings.md
@@ -8,10 +8,10 @@ title: "Prepare For Meetings"
 Some considerations for successfully preparing a meeting:
 
 - clarify and communicate the <dfn data-info="Driver: A person’s or a group&apos;s motive for responding to a specific situation.">driver</dfn> for, and <dfn data-info="Intended Outcome: The expected result of an agreement, action, project or strategy.">intended outcome</dfn> of the meeting
-- decide who to invite 
+- decide who to invite
 - create an agenda
 - schedule the meeting enough in advance, so people have time to prepare
-- choose an appropriate duration for the meeting 
+- choose an appropriate duration for the meeting
 - be clear who will [facilitate the meeting](facilitate-meetings.html), who will take minutes and who will take care of any follow-up
 
 ### Preparing an Agenda
@@ -20,10 +20,10 @@ Involve people in preparing and prioritizing an agenda and send it out in advanc
 
 For each agenda item agree on:
 
-- the driver 
+- the driver
 - the intended outcome
 - the process
-- the time you want to spend on it 
+- the time you want to spend on it
 - what people need to do to prepare
 
 ### Support the Participants' Preparation

--- a/docs/proposal-forming.md
+++ b/docs/proposal-forming.md
@@ -14,7 +14,7 @@ _Proposal Forming_ may also be used by an individual.
 
 ### Proposal Forming Steps
 
-**Consent to driver:** Briefly present the <dfn data-info="Organizational Driver: A driver is a person’s or a group&apos;s motive for responding to a specific situation. A driver is considered an **organizational driver** if responding to it would help the organization generate value, eliminate waste or avoid harm.">driver</dfn>. _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_ 
+**Consent to driver:** Briefly present the <dfn data-info="Organizational Driver: A driver is a person’s or a group&apos;s motive for responding to a specific situation. A driver is considered an **organizational driver** if responding to it would help the organization generate value, eliminate waste or avoid harm.">driver</dfn>. _Is this driver relevant for us to respond to? Are there any essential amendments to what has been presented?_
 
 **Deepen shared understanding of driver:** invite essential questions to understand the driver in more detail.
 
@@ -30,7 +30,7 @@ _Proposal Forming_ may also be used by an individual.
 
 ### Choosing Tuners
 
-Consider: 
+Consider:
 
 -   who should be there?
 -   who wants to be there?

--- a/docs/pull-system-for-work.md
+++ b/docs/pull-system-for-work.md
@@ -7,7 +7,7 @@ title: "Pull-System For Work"
 
 Prioritize pending work items to ensure that important items are worked on first.
 
-Pulling in work prevents overloading the system, especially when [work in progress (WIP) per person or team is limited](limit-work-in-progress.html). 
+Pulling in work prevents overloading the system, especially when [work in progress (WIP) per person or team is limited](limit-work-in-progress.html).
 
 
 [&#9654; Limit Work In Progress](limit-work-in-progress.html)<br/>[&#9664; Visualize Work](visualize-work.html)<br/>[&#9650; Organizing Work](organizing-work.html)

--- a/docs/respond-to-organizational-drivers.md
+++ b/docs/respond-to-organizational-drivers.md
@@ -8,7 +8,7 @@ title: "Respond to Organizational Drivers"
 Responses to <dfn data-info="Organizational Driver: A driver is a person’s or a group&apos;s motive for responding to a specific situation. A driver is considered an **organizational driver** if responding to it would help the organization generate value, eliminate waste or avoid harm.">organizational drivers</dfn> include:
 
 - direct action (<dfn data-info="Operations: Doing the work and organizing day to day activities within the constraints defined through governance.">operations</dfn>)
-- organizing how work will be done 
+- organizing how work will be done
 - making governance decisions
 
 The response to an organizational driver is typically treated as an experiment that is evaluated and evolved over time.

--- a/docs/retrospective.md
+++ b/docs/retrospective.md
@@ -14,7 +14,7 @@ title: "Retrospective"
 
 ### Five Phases of a Retrospective Meeting
 
-1. Set the stage 
+1. Set the stage
 2. Gather data
 3. Generate insights
 4. Decide what to do

--- a/docs/role-selection.md
+++ b/docs/role-selection.md
@@ -27,7 +27,7 @@ A prerequisite to the selection process is a [clear description](clarify-domains
     -   proposing a nominee themselves or asking a group member
     -   inviting (some) nominees to agree who should be proposed
     -   inviting group dialogue to help reveal the strongest nominee
-7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an <dfn data-info="Objection: An argument demonstrating (or revealing) how a (proposed) agreement or activity can lead to unintended consequences, or that there are worthwhile ways to improve it.">objection</dfn>. 
+7. **Check for Objections:** Ask participants (including the proposed nominee) to simultaneously signal whether or not they have an <dfn data-info="Objection: An argument demonstrating (or revealing) how a (proposed) agreement or activity can lead to unintended consequences, or that there are worthwhile ways to improve it.">objection</dfn>.
 8. **Address and Resolve Objections,** beginning with any from the proposed nominee. [Objections may be resolved](resolve-objections.html) in many ways, including amending the role's domain description or by nominating someone else. When all objections are resolved, check with the (final) nominee again if they accept the role.
 9. **Celebrate:** Acknowledge reaching agreement and thank the person who will now keep the role.
 

--- a/docs/role.md
+++ b/docs/role.md
@@ -18,7 +18,7 @@ A role is a simple way for an organization (or <dfn data-info="Team: A group of 
 
 A role keeper may maintain a governance <dfn data-info="Backlog: A list of (often prioritized) uncompleted work items (deliverables), or (drivers) that need to be addressed.">backlog</dfn>, and a <dfn data-info="Logbook: A (digital) system to store all information relevant for running an organization.">logbook</dfn> to record and help them evolve their approach toward delivering <dfn data-info="Value: The importance, worth or usefulness of something in relation to a driver. Also &quot;a principle of some significance that guides behavior&quot; (mostly used as plural, &quot;values&quot;, or &quot;organizational values&quot;).">value</dfn>.
 
-**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.  
+**Note:** In S3, guidelines, processes or protocols created by individuals in roles are treated as agreements.
 
 ![People can take responsibility for more than one role](img/illustrations/roles.png)
 

--- a/docs/rounds.md
+++ b/docs/rounds.md
@@ -7,11 +7,11 @@ title: "Rounds"
 
 Rounds are a group facilitation technique to maintain equivalence and support effective dialogue.
 
-Be clear on the purpose and intended outcome of each round. 
+Be clear on the purpose and intended outcome of each round.
 
 Sit in a circle, begin each round with a different person, and change direction (clockwise or counterclockwise) to bring variation to who speaks first and last, and to the order of contributions.
 
-![Rounds](img/circle/rounds.png) 
+![Rounds](img/circle/rounds.png)
 
 
 [&#9654; Facilitate Meetings](facilitate-meetings.html)<br/>[&#9650; Meeting Practices](meeting-practices.html)

--- a/docs/service-organization.md
+++ b/docs/service-organization.md
@@ -3,7 +3,7 @@ title: "Service Organization"
 ---
 
 
-**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).** 
+**Multi-stakeholder collaboration and alignment towards a shared driver (or objective).**
 
 -   improves potential for equivalence between various entities
 -   increases cross-departmental/organizational alignment

--- a/docs/support-role.md
+++ b/docs/support-role.md
@@ -4,7 +4,7 @@ title: "Support Role"
 
 
 **Apply the role pattern to external contractors.**
-    
+
 -   clarify and describe the <dfn data-info="Organizational Driver: A driver is a person’s or a group&apos;s motive for responding to a specific situation. A driver is considered an **organizational driver** if responding to it would help the organization generate value, eliminate waste or avoid harm.">driver</dfn> for the [role](role.html)
 -   create a [domain description](clarify-domains.html)
 -   if valuable, implement a selection process

--- a/docs/transparent-salary.md
+++ b/docs/transparent-salary.md
@@ -11,7 +11,7 @@ A transparent salary formula needs to suit an organization's context, and to be 
 
 Perception of fairness varies from person to person and according to context, so creating a salary formula requires developing a shared understanding of what is considered fair.
 
-When deciding (or agreeing) on a salary formula for an organization or department, consider: 
+When deciding (or agreeing) on a salary formula for an organization or department, consider:
 
 - what would be a suitable fixed subsistence guarantee
 - how to calculate compensation according to need, investment, productivity, or merit

--- a/docs/visualize-work.md
+++ b/docs/visualize-work.md
@@ -12,7 +12,7 @@ title: "Visualize Work"
 
 ![Visualization of a simple work process](img/workflow-and-value/simple-process.png)
 
-### Things to track: 
+### Things to track:
 
 -   **types of work items** (e.g. customer request, project tasks, reporting tasks, rework)
 -   **start date** (and **due date** if necessary)

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Sociocracy 3.0 - A Practical Guide
 
-This repository contains the source file for  a slide deck for teaching Sociocracy 3.0, currently available as 
+This repository contains the source file for  a slide deck for teaching Sociocracy 3.0, currently available as:
 
 * fast and mobile friendly static html pages: <http://patterns.sociocracy30.org>
 * [online presentation](http://patterns.sociocracy30.org/slides.html)
-* various other download formats, see  [sociocracy30.org/guide/](http://sociocracy30.org/guide/) 
+* various other download formats, see  [sociocracy30.org/guide/](http://sociocracy30.org/guide/)
 
 German, Hebrew and French versions also exist and are also available via [sociocracy30.org/guide/](http://sociocracy30.org/guide/). If you want to help with translations into your language, please take a look at the [translations page](http://sociocracy30.org/translations/).
 
@@ -33,14 +33,14 @@ The main format for the practical guide is a Jekyll website on <https://patterns
 
 Downloads are currently available as PDF or PNG slides exported from [Deckset](decksetapp.com), as a html-version in [reveal.js](http://lab.hakim.se/reveal-js/#/) a static website (using jekyll and GitHub pages), and as e-books (ePub and PDF).
 
-Deckset is nice to quickly hack together a beautiful presentation, but is a bit lacking when it comes to navigating larger presentations, and it's only available as a macOS app. Building the Hebrew version I discovered the hard way it does not support RTL languages., and did not find a way to automate pdf export, so with a growing number of languages Deckset is becoming increasingly painful. 
+Deckset is nice to quickly hack together a beautiful presentation, but is a bit lacking when it comes to navigating larger presentations, and it's only available as a macOS app. Building the Hebrew version I discovered the hard way it does not support RTL languages., and did not find a way to automate pdf export, so with a growing number of languages Deckset is becoming increasingly painful.
 
 This is why I was looking at more open formats, and developed a generator for reveal.js, which generally works, but there might still a few small glitches in the CSS. Ping me if you find one. You can see it in action at <https://patterns.sociocracy30.org/slides.html>
 
 [Reveal.js docs](https://github.com/hakimel/reveal.js/blob/master/README.md)
 
 Exporting to epub (via pandoc) and pdf via LaTEX is working, but still rough around the edges. The epub will benefit from a stylesheet and setting some [metadata for ibooks](http://pandoc.org/MANUAL.html#epub-metadata), while the styles for the pdf need some cleanup in all but the German versions.
- 
+
 ## Markdown Styleguide
 
 Information in this section is preliminary, and needs further testing.
@@ -61,7 +61,7 @@ Keep (or adapt) `custom-styles.css` and `custom-theme.css` (derived from `css/th
 
 ## Translations
 
-Slides are translated in a [dedicated crowdin project](https://crowdin.com/project/sociocracy-30). The repository contains `crowdin.yaml` for use with the [crowdin CLI](https://support.crowdin.com/cli-tool/). 
+Slides are translated in a [dedicated crowdin project](https://crowdin.com/project/sociocracy-30). The repository contains `crowdin.yaml` for use with the [crowdin CLI](https://support.crowdin.com/cli-tool/).
 
 Uploading sources is handled through this command (remove `--dryrun` to run):
 
@@ -71,13 +71,13 @@ For each major revision we will create a branch with the version tag in crowdin,
 
 `crowdin --identity ~/crowdin-s3-patterns.yaml upload sources -b {branch name} --dryrun`
 
-The config file can be checked using 
+The config file can be checked using
 `crowdin --identity ~/crowdin-s3-patterns.yaml lint`
 
  These commands assume [crowdin credentials](https://support.crowdin.com/configuration-file/#cli-2) in `~/crowdin-s3-patterns.yaml`
 
 
-## License 
+## License
 
 [![](http://creativecommons.org/images/deed/seal.png)](http://creativecommons.org/freeworks)
 
@@ -90,7 +90,7 @@ Basically this license grants you
 1. Freedom to use the work itself.
 2. Freedom to use the information in the work for any purpose, even commercially.
 3. Freedom to share copies of the work for any purpose, even commercially.
-4. Freedom to make and share remixes and other derivatives for any purpose. 
+4. Freedom to make and share remixes and other derivatives for any purpose.
 
 You need to attribute the original creator of the materials, and all derivatives need to be shared under the same license. There's more on the topic of free culture on the [Creative Commons website.](http://creativecommons.org/freeworks)
 


### PR DESCRIPTION
incidentally, it's not clear yet to me what the proper way to make changes is. Obviously, the typo has some main source file and the other cases are built or generated from that. I just manually fixed them all in this case, but is there a document that explains how to contribute better?