### PR TITLE
patch for #12 extra invalid comma

### DIFF
--- a/content/glossary.yaml
+++ b/content/glossary.yaml
@@ -103,8 +103,8 @@ terms:
     glossary: Deliverables traveling through an organization towards customers or other stakeholders.
   governance:
     name: Governance
-    definition: "**Governance** in an organization (or a domain within it) is the act of setting objectives, and making and evolving decisions that guide people towards achieving them."
-    glossary: The act of setting objectives, and making and evolving decisions that guide people towards achieving them.
+    definition: "**Governance** in an organization (or a domain within it) is the act of setting objectives, making and evolving decisions that guide people towards achieving them."
+    glossary: The act of setting objectives, making and evolving decisions that guide people towards achieving them.
   governance-backlog:
     name: Governance Backlog
     definition: A **governance backlog** is a visible, prioritized list of items (drivers) that are related to governing a domain and require attention.


### PR DESCRIPTION
this patch proposes to fix the issue #2 issue  by removing unnecessary 'and' after comma in glossary definition for Governance