### PR TITLE
Fix links on double-linked-hierarchy

### DIFF
--- a/docs/double-linked-hierarchy.md
+++ b/docs/double-linked-hierarchy.md
@@ -15,7 +15,7 @@ A double-linked hierarchy:
 
 ![A double-linked hierarchy: not your typical hierarchy](img/structural-patterns/double-linked-hierarchy.png)
 
-**See also:** [Circle](Circle.html), [Double Linking](Double-Linking.html), [Representative](Representative.html)
+**See also:** [Circle](circle.html), [Double Linking](double-linking.html), [Representative](representative.html)
 
 [&#9654; Service Organization](service-organization.html)<br/>[&#9664; Peach Organization](peach-organization.html)<br/>[&#9650; Organizational Structure](organizational-structure.html)
 


### PR DESCRIPTION
Links were capitalised making them 404 on live site as most webservers
are case sensitive.